### PR TITLE
feat: add minimum gain threshold for writes

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -171,6 +171,12 @@ Options:
       --force
           Write the output even if it is larger than the input
 
+      --min-gain <value>
+          Only write optimized output when savings meet this threshold. Accepts percentages
+          (e.g. 1%, 0.5%) or byte sizes (e.g. 1024, 4KiB, 1MB).
+          
+          If savings is below the threshold, it is treated as no-change.
+
   -z, --zopfli
           Use the much slower but stronger Zopfli compressor for main compression trials.
           Recommended use is with '-o max' and '--fast'.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The most commonly used options are as follows:
 - Optimization: `-o 0` through `-o 6` (or `-o max`), lower is faster, higher is better compression.
   The default (`-o 2`) is quite fast and provides good compression. Higher levels can be notably
   better* but generally have increasingly diminishing returns.
+- Minimum gain: `--min-gain <value>` only writes optimized output when savings reach a threshold.
+  Use a percentage (`1%`, `0.5%`) or bytes (`1024`, `4KiB`, `1MB`).
 - Strip: Used to remove metadata info from processed images. Used via `--strip [safe,all]`.
   Can save a few kilobytes if you don't need the metadata. "Safe" removes only metadata that
   will never affect rendering of the image. "All" removes all metadata that is not critical

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -341,6 +341,19 @@ be processed successfully. The output will always have correct checksums.")
                 .action(ArgAction::SetTrue),
         )
         .arg(
+            Arg::new("min-gain")
+                .help("Require savings of at least <value> before writing")
+                .long_help("\
+Only write optimized output if savings meets this threshold. The value may be specified as \
+a percentage (e.g. '1%' or '0.5%') or as a byte size (e.g. '1024', '4KiB', '1MB').
+
+If savings is below the threshold, the result is treated as no-change:
+    - in-place output will not overwrite the input file
+    - explicit output path, stdout, and dry-run will use original data")
+                .long("min-gain")
+                .value_name("value"),
+        )
+        .arg(
             Arg::new("zopfli")
                 .help("Use the much slower but stronger Zopfli compressor")
                 .long_help("\

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,4 +1,10 @@
-use std::{fs, fs::File, io::prelude::*};
+use std::{
+    fs,
+    fs::File,
+    io::prelude::*,
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use oxipng::*;
 
@@ -86,4 +92,92 @@ fn optimize_srgb_icc() {
     opts.strip = StripChunks::Safe;
     let result = oxipng::optimize_from_memory(&file, &opts);
     assert!(result.unwrap().len() < 1000);
+}
+
+fn temp_path(name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("oxipng-{name}-{}-{nanos}.png", std::process::id()))
+}
+
+#[test]
+fn min_gain_bytes_skips_in_place_write() {
+    let input_data = fs::read("tests/files/verbose_mode.png").unwrap();
+    let opts = Options::default();
+    let optimized = oxipng::optimize_from_memory(&input_data, &opts).unwrap();
+    assert!(
+        optimized.len() < input_data.len(),
+        "fixture should produce measurable savings"
+    );
+    let savings = input_data.len() - optimized.len();
+
+    let input_path = temp_path("min-gain-bytes-input");
+    fs::write(&input_path, &input_data).unwrap();
+    let mut permissions = fs::metadata(&input_path).unwrap().permissions();
+    permissions.set_readonly(true);
+    fs::set_permissions(&input_path, permissions).unwrap();
+
+    let result = oxipng::optimize_with(
+        &InFile::Path(input_path.clone()),
+        &OutFile::Path {
+            path: None,
+            preserve_attrs: false,
+        },
+        &opts,
+        Some(MinGain::Bytes(savings + 1)),
+    )
+    .unwrap();
+    assert_eq!(result, (input_data.len(), input_data.len()));
+    assert_eq!(fs::read(&input_path).unwrap(), input_data);
+
+    let mut permissions = fs::metadata(&input_path).unwrap().permissions();
+    permissions.set_readonly(false);
+    fs::set_permissions(&input_path, permissions).unwrap();
+    fs::remove_file(&input_path).ok();
+}
+
+#[test]
+fn min_gain_percentage_threshold_behavior() {
+    let input_data = fs::read("tests/files/verbose_mode.png").unwrap();
+    let opts = Options::default();
+    let optimized = oxipng::optimize_from_memory(&input_data, &opts).unwrap();
+    assert!(
+        optimized.len() < input_data.len(),
+        "fixture should produce measurable savings"
+    );
+    let savings_ratio = (input_data.len() - optimized.len()) as f64 / input_data.len() as f64;
+    let high_threshold = MinGain::ratio((savings_ratio + 0.001).min(1.0)).unwrap();
+    let low_threshold = MinGain::ratio(savings_ratio / 2.0).unwrap();
+
+    let input_path = temp_path("min-gain-percent-input");
+    let high_output = temp_path("min-gain-percent-high");
+    let low_output = temp_path("min-gain-percent-low");
+    fs::write(&input_path, &input_data).unwrap();
+
+    let high_result = oxipng::optimize_with(
+        &InFile::Path(input_path.clone()),
+        &OutFile::from_path(high_output.clone()),
+        &opts,
+        Some(high_threshold),
+    )
+    .unwrap();
+    assert_eq!(high_result, (input_data.len(), input_data.len()));
+    assert_eq!(fs::read(&high_output).unwrap(), input_data);
+
+    let low_result = oxipng::optimize_with(
+        &InFile::Path(input_path.clone()),
+        &OutFile::from_path(low_output.clone()),
+        &opts,
+        Some(low_threshold),
+    )
+    .unwrap();
+    assert_eq!(low_result.0, input_data.len());
+    assert!(low_result.1 < input_data.len());
+    assert_eq!(fs::read(&low_output).unwrap().len(), low_result.1);
+
+    fs::remove_file(&input_path).ok();
+    fs::remove_file(&high_output).ok();
+    fs::remove_file(&low_output).ok();
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -132,9 +132,6 @@ fn min_gain_bytes_skips_in_place_write() {
     assert_eq!(result, (input_data.len(), input_data.len()));
     assert_eq!(fs::read(&input_path).unwrap(), input_data);
 
-    let mut permissions = fs::metadata(&input_path).unwrap().permissions();
-    permissions.set_readonly(false);
-    fs::set_permissions(&input_path, permissions).unwrap();
     fs::remove_file(&input_path).ok();
 }
 


### PR DESCRIPTION
Split from the previous combined PR so this feature can be reviewed independently.

## Summary
- add `--min-gain <value>` CLI option (accepts percentages and byte sizes)
- thread optional `MinGain` through CLI and optimization paths
- add `optimize_with` / `optimize_from_memory_with` APIs
- treat below-threshold savings as no-change for write behavior
- update docs and tests for min-gain parsing/behavior