### PR TITLE
Add option for progress bar that also shows cumulative savings.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ clap = { version = "4.6.0", optional = true, features = ["wrap_help"] }
 env_logger = { version = "0.11.10", optional = true, default-features = false, features = ["auto-color"] }
 image = { version = "0.25.9", optional = true, default-features = false, features = ["png"] }
 indexmap = "2.14.0"
+indicatif = { version = "0.17.11", optional = true, features = ["rayon"] }
 libdeflater = "1.25.2"
 log = "0.4.31"
 parse-size = { version = "1.1.0", optional = true }
@@ -57,9 +58,9 @@ glob = { version = "0.3.3", optional = true }
 serde_json = "1.0.150"
 
 [features]
-binary = ["dep:clap", "dep:glob", "dep:env_logger", "dep:parse-size"]
+binary = ["dep:clap", "dep:glob", "dep:env_logger", "dep:parse-size", "dep:indicatif"]
 default = ["binary", "parallel", "zopfli"]
-parallel = ["dep:rayon", "indexmap/rayon"]
+parallel = ["dep:rayon", "indexmap/rayon", "indicatif?/rayon"]
 freestanding = ["libdeflater/freestanding"]
 sanity-checks = ["dep:image"]
 zopfli = ["dep:zopfli"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,13 +42,13 @@ clap = { version = "4.6.0", optional = true, features = ["wrap_help"] }
 env_logger = { version = "0.11.10", optional = true, default-features = false, features = ["auto-color"] }
 image = { version = "0.25.9", optional = true, default-features = false, features = ["png"] }
 indexmap = "2.14.0"
-indicatif = { version = "0.17.11", optional = true, features = ["rayon"] }
 libdeflater = "1.25.2"
 log = "0.4.31"
 parse-size = { version = "1.1.0", optional = true }
 rayon = { version = "1.11.0", optional = true }
 rgb = "0.8.53"
 rustc-hash = "2.1.2"
+terminal_size = { version = "0.4.4", optional = true }
 zopfli = { version = "0.8.3", optional = true, default-features = false, features = ["std", "zlib"] }
 
 [target.'cfg(windows)'.dependencies]
@@ -58,9 +58,9 @@ glob = { version = "0.3.3", optional = true }
 serde_json = "1.0.150"
 
 [features]
-binary = ["dep:clap", "dep:glob", "dep:env_logger", "dep:parse-size", "dep:indicatif"]
+binary = ["dep:clap", "dep:glob", "dep:env_logger", "dep:parse-size", "dep:terminal_size"]
 default = ["binary", "parallel", "zopfli"]
-parallel = ["dep:rayon", "indexmap/rayon", "indicatif?/rayon"]
+parallel = ["dep:rayon", "indexmap/rayon"]
 freestanding = ["libdeflater/freestanding"]
 sanity-checks = ["dep:image"]
 zopfli = ["dep:zopfli"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -235,21 +235,6 @@ losslessly.")
                 .conflicts_with("stdout"),
         )
         .arg(
-            Arg::new("progress")
-                .help("Show a progress bar with cumulative size savings")
-                .long_help("\
-Show a progress bar while processing files, tracking how many files have completed along \
-with the cumulative reduction in file size so far.
-
-Requires an interactive terminal, and has no effect when combined with '--verbose', \
-'--quiet', or '--stdout'.")
-                .long("progress")
-                .action(ArgAction::SetTrue)
-                .conflicts_with("verbose")
-                .conflicts_with("quiet")
-                .conflicts_with("stdout"),
-        )
-        .arg(
             Arg::new("filters")
                 .help("Filters to try (0-9; see '--help' for details)")
                 .long_help("\

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -235,6 +235,21 @@ losslessly.")
                 .conflicts_with("stdout"),
         )
         .arg(
+            Arg::new("progress")
+                .help("Show a progress bar with cumulative size savings")
+                .long_help("\
+Show a progress bar while processing files, tracking how many files have completed along \
+with the cumulative reduction in file size so far.
+
+Requires an interactive terminal, and has no effect when combined with '--verbose', \
+'--quiet', or '--stdout'.")
+                .long("progress")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("verbose")
+                .conflicts_with("quiet")
+                .conflicts_with("stdout"),
+        )
+        .arg(
             Arg::new("filters")
                 .help("Filters to try (0-9; see '--help' for details)")
                 .long_help("\

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,13 +9,16 @@ use std::{
     io::{IsTerminal, Write, stdout},
     path::PathBuf,
     process::ExitCode,
-    sync::atomic::{AtomicUsize, Ordering::AcqRel},
+    sync::atomic::{AtomicI64, AtomicUsize, Ordering::AcqRel},
     time::Duration,
 };
 
 use clap::ArgMatches;
 mod cli;
 use indexmap::IndexSet;
+#[cfg(feature = "parallel")]
+use indicatif::ParallelProgressIterator;
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressIterator, ProgressStyle};
 use log::{Level, LevelFilter, error, warn};
 #[cfg(feature = "zopfli")]
 use oxipng::ZopfliOptions;
@@ -87,26 +90,60 @@ fn main() -> ExitCode {
 
     let print_summary = !matches.get_flag("quiet") && !using_stdout;
     let print_progress = print_summary && !is_verbose && stdout().is_terminal();
+    let show_progress_bar = print_progress && matches.get_flag("progress");
     let total_files = files.len();
     let num_processed = AtomicUsize::new(0);
-    if print_progress {
+    let cumulative_saved = AtomicI64::new(0);
+
+    let progress_bar = show_progress_bar.then(|| {
+        let pb =
+            ProgressBar::with_draw_target(Some(total_files as u64), ProgressDrawTarget::stdout());
+        pb.set_style(
+            ProgressStyle::with_template("[{wide_bar:.cyan/blue}] {pos}/{len} | saved {msg}")
+                .unwrap()
+                .progress_chars("=>-"),
+        );
+        pb.set_message(format_bytes(0, false));
+        pb
+    });
+    if print_progress && progress_bar.is_none() {
         print!("Files processed: 0/{}...", total_files);
         stdout().flush().ok();
     }
     let process = |(input, output): &(InFile, OutFile)| {
         let result = process_file(input, output, &opts);
-        if print_progress && matches!(result, OptimizationResult::Ok(_)) {
-            let value = num_processed.fetch_add(1, AcqRel) + 1;
-            print!("\rFiles processed: {}/{}...", value, total_files);
-            stdout().flush().ok();
+        if print_progress && let Ok((insize, outsize)) = result {
+            if let Some(pb) = &progress_bar {
+                let delta = insize as i64 - outsize as i64;
+                let saved = cumulative_saved.fetch_add(delta, AcqRel) + delta;
+                pb.set_message(format_bytes(saved, false));
+            } else {
+                let value = num_processed.fetch_add(1, AcqRel) + 1;
+                print!("\rFiles processed: {}/{}...", value, total_files);
+                stdout().flush().ok();
+            }
         }
         result
     };
-    let results: Vec<OptimizationResult> = if matches.get_flag("parallel-files") {
-        files.par_iter().map(process).collect()
-    } else {
-        files.iter().map(process).collect()
+    let results: Vec<OptimizationResult> = match (&progress_bar, matches.get_flag("parallel-files"))
+    {
+        (Some(pb), true) => files
+            .par_iter()
+            .map(process)
+            .progress_with(pb.clone())
+            .collect(),
+        (Some(pb), false) => files
+            .iter()
+            .map(process)
+            .progress_with(pb.clone())
+            .collect(),
+        (None, true) => files.par_iter().map(process).collect(),
+        (None, false) => files.iter().map(process).collect(),
     };
+
+    if let Some(pb) = progress_bar {
+        pb.finish_and_clear();
+    }
 
     // Collect stats
     let mut num_succeeded = 0;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,16 +9,14 @@ use std::{
     io::{IsTerminal, Write, stdout},
     path::PathBuf,
     process::ExitCode,
-    sync::atomic::{AtomicI64, AtomicUsize, Ordering::AcqRel},
+    sync::atomic::{AtomicI64, Ordering::AcqRel},
     time::Duration,
 };
 
 use clap::ArgMatches;
 mod cli;
+mod progress;
 use indexmap::IndexSet;
-#[cfg(feature = "parallel")]
-use indicatif::ParallelProgressIterator;
-use indicatif::{ProgressBar, ProgressDrawTarget, ProgressIterator, ProgressStyle};
 use log::{Level, LevelFilter, error, warn};
 #[cfg(feature = "zopfli")]
 use oxipng::ZopfliOptions;
@@ -90,55 +88,26 @@ fn main() -> ExitCode {
 
     let print_summary = !matches.get_flag("quiet") && !using_stdout;
     let print_progress = print_summary && !is_verbose && stdout().is_terminal();
-    let show_progress_bar = print_progress && matches.get_flag("progress");
     let total_files = files.len();
-    let num_processed = AtomicUsize::new(0);
     let cumulative_saved = AtomicI64::new(0);
 
-    let progress_bar = show_progress_bar.then(|| {
-        let pb =
-            ProgressBar::with_draw_target(Some(total_files as u64), ProgressDrawTarget::stdout());
-        pb.set_style(
-            ProgressStyle::with_template("[{wide_bar:.cyan/blue}] {pos}/{len} | saved {msg}")
-                .unwrap()
-                .progress_chars("=>-"),
-        );
-        pb.set_message(format_bytes(0, false));
-        pb
-    });
-    if print_progress && progress_bar.is_none() {
-        print!("Files processed: 0/{}...", total_files);
-        stdout().flush().ok();
-    }
+    let progress_bar = print_progress.then(|| progress::ProgressBar::new(total_files as u64));
     let process = |(input, output): &(InFile, OutFile)| {
         let result = process_file(input, output, &opts);
-        if print_progress && let Ok((insize, outsize)) = result {
-            if let Some(pb) = &progress_bar {
+        if let Some(pb) = &progress_bar {
+            let message = result.as_ref().ok().map(|&(insize, outsize)| {
                 let delta = insize as i64 - outsize as i64;
                 let saved = cumulative_saved.fetch_add(delta, AcqRel) + delta;
-                pb.set_message(format_bytes(saved, false));
-            } else {
-                let value = num_processed.fetch_add(1, AcqRel) + 1;
-                print!("\rFiles processed: {}/{}...", value, total_files);
-                stdout().flush().ok();
-            }
+                format_bytes(saved, false)
+            });
+            pb.inc(message);
         }
         result
     };
-    let results: Vec<OptimizationResult> = match (&progress_bar, matches.get_flag("parallel-files"))
-    {
-        (Some(pb), true) => files
-            .par_iter()
-            .map(process)
-            .progress_with(pb.clone())
-            .collect(),
-        (Some(pb), false) => files
-            .iter()
-            .map(process)
-            .progress_with(pb.clone())
-            .collect(),
-        (None, true) => files.par_iter().map(process).collect(),
-        (None, false) => files.iter().map(process).collect(),
+    let results: Vec<OptimizationResult> = if matches.get_flag("parallel-files") {
+        files.par_iter().map(process).collect()
+    } else {
+        files.iter().map(process).collect()
     };
 
     if let Some(pb) = progress_bar {

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,102 @@
+use std::{
+    io::{Write, stdout},
+    sync::Mutex,
+};
+
+const FILLED: char = '=';
+const HEAD: char = '>';
+const EMPTY: char = '-';
+
+const CYAN: &str = "\x1b[36m";
+const BLUE: &str = "\x1b[34m";
+const RESET: &str = "\x1b[0m";
+
+const DEFAULT_WIDTH: usize = 80;
+
+#[derive(Debug)]
+struct State {
+    pos: u64,
+    message: String,
+}
+
+#[derive(Debug)]
+pub struct ProgressBar {
+    total: u64,
+    state: Mutex<State>,
+}
+
+impl ProgressBar {
+    pub fn new(total: u64) -> Self {
+        let pb = Self {
+            total,
+            state: Mutex::new(State {
+                pos: 0,
+                message: String::new(),
+            }),
+        };
+        pb.draw(0, "");
+        pb
+    }
+
+    pub fn inc(&self, message: Option<String>) {
+        let mut state = self.state.lock().unwrap();
+        state.pos = (state.pos + 1).min(self.total);
+        if let Some(message) = message {
+            state.message = message;
+        }
+        self.draw(state.pos, &state.message);
+    }
+
+    pub fn finish_and_clear(&self) {
+        let mut out = stdout();
+
+        let _ = write!(out, "\r\x1b[K");
+        let _ = out.flush();
+    }
+
+    fn draw(&self, pos: u64, message: &str) {
+        let width = terminal_width();
+        let total = self.total;
+
+        let suffix = format!(" {pos}/{total} | saved {message} ");
+
+        let bar_width = width.saturating_sub(suffix.len() + 2).max(1);
+
+        let filled = if total == 0 {
+            bar_width
+        } else {
+            ((bar_width as u64 * pos) / total).min(bar_width as u64) as usize
+        };
+
+        let has_head = pos < total && filled < bar_width;
+        let head_len = usize::from(has_head);
+        let empty_len = bar_width - filled - head_len;
+
+        let mut bar = String::with_capacity(bar_width + 2 * (CYAN.len() + RESET.len()));
+        bar.push_str(CYAN);
+        for _ in 0..filled {
+            bar.push(FILLED);
+        }
+        if has_head {
+            bar.push(HEAD);
+        }
+        bar.push_str(RESET);
+        bar.push_str(BLUE);
+        for _ in 0..empty_len {
+            bar.push(EMPTY);
+        }
+        bar.push_str(RESET);
+
+        let line = format!("[{bar}]{suffix}");
+        let mut out = stdout();
+
+        let _ = write!(out, "\r{line}\x1b[K");
+        let _ = out.flush();
+    }
+}
+
+fn terminal_width() -> usize {
+    terminal_size::terminal_size()
+        .map(|(width, _)| width.0 as usize)
+        .unwrap_or(DEFAULT_WIDTH)
+}


### PR DESCRIPTION
Adds --progress option for showing a progress bar. Useful when using -r to process all PNGs in a folder. 