### PR TITLE
CI: include the short commit hash in built artifacts

### DIFF
--- a/.github/actions/build-id/action.yml
+++ b/.github/actions/build-id/action.yml
@@ -1,0 +1,28 @@
+name: Build ID
+description: Compute the short commit hash and the CI binary artifact name
+
+inputs:
+  target:
+    description: Rust target triple the binary is built for
+    required: true
+
+outputs:
+  short-sha:
+    description: The first 7 characters of the commit hash
+    value: ${{ steps.build-id.outputs.short-sha }}
+  artifact-name:
+    description: The name of the CI binary artifact for the target
+    value: ${{ steps.build-id.outputs.artifact-name }}
+
+runs:
+  using: composite
+  steps:
+    - id: build-id
+      shell: bash
+      env:
+        COMMIT_SHA: ${{ github.sha }}
+        TARGET: ${{ inputs.target }}
+      run: |
+        SHORT_SHA="${COMMIT_SHA::7}"
+        echo "short-sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+        echo "artifact-name=Oxipng binary ($TARGET, $SHORT_SHA)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,15 +67,23 @@ jobs:
           echo "version=$(cargo metadata --format-version 1 --no-deps |
           jq -r '.packages[] | select(.name == "oxipng").version')" >> "$GITHUB_OUTPUT"
 
+      - name: Get the build ID
+        id: build-id
+        uses: $/.github/actions/build-id
+        with:
+          target: ${{ matrix.target }}
+
       - name: Retrieve ${{ matrix.target }} binary
         uses: dawidd6/action-download-artifact@d63b86af1b34672e53c440b1b83979861906bad7 # v24
         with:
           workflow: oxipng.yml
           commit: ${{ github.sha }}
-          name: Oxipng binary (${{ matrix.target }})
+          name: ${{ steps.build-id.outputs.artifact-name }}
           path: target
 
       - name: Generate up to date manual
+        env:
+          OXIPNG_BUILD_REVISION: ${{ steps.build-id.outputs.short-sha }}
         run: scripts/manual.sh
 
       - name: Build archives
@@ -83,8 +91,9 @@ jobs:
         env:
           VERSION: ${{ steps.oxipngMeta.outputs.version }}
           TARGET: ${{ matrix.target }}
+          SHORT_SHA: ${{ steps.build-id.outputs.short-sha }}
         run: |
-          ARCHIVE_NAME="oxipng-$VERSION-$TARGET"
+          ARCHIVE_NAME="oxipng-$VERSION-$SHORT_SHA-$TARGET"
 
           mkdir "$ARCHIVE_NAME"
           cp ../CHANGELOG.md ../README.md ../MANUAL.txt "$ARCHIVE_NAME"

--- a/.github/workflows/oxipng.yml
+++ b/.github/workflows/oxipng.yml
@@ -128,15 +128,22 @@ jobs:
         if: matrix.target == 'x86_64-unknown-linux-gnu'
         run: cargo doc --release --no-deps
 
+      - name: Get the build ID
+        id: build-id
+        uses: $/.github/actions/build-id
+        with:
+          target: ${{ matrix.target }}
+
       - name: Build CLI binary
         run: cargo build --release -Zbuild-std
         env:
           RUSTFLAGS: "-Zlocation-detail=none -Zunstable-options -Cpanic=immediate-abort"
+          OXIPNG_BUILD_REVISION: ${{ steps.build-id.outputs.short-sha }}
 
       - name: Upload CLI binary as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: Oxipng binary (${{ matrix.target }})
+          name: ${{ steps.build-id.outputs.artifact-name }}
           path: |
             target/${{ env.CARGO_BUILD_TARGET }}/release/oxipng
             target/${{ env.CARGO_BUILD_TARGET }}/release/oxipng.exe

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ name = "zopfli"
 required-features = ["zopfli"]
 
 [dependencies]
-clap = { version = "4.6.0", optional = true, features = ["wrap_help"] }
+clap = { version = "4.6.0", optional = true, features = ["string", "wrap_help"] }
 env_logger = { version = "0.11.10", optional = true, default-features = false, features = ["auto-color"] }
 image = { version = "0.25.9", optional = true, default-features = false, features = ["png"] }
 indexmap = "2.14.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -15,6 +15,22 @@ const STYLES: Styles = Styles::styled()
     .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
     .placeholder(AnsiColor::Cyan.on_default());
 
+// Set at build time by CI to the commit the binary was built from
+const BUILD_REVISION: Option<&str> = option_env!("OXIPNG_BUILD_REVISION");
+
+// An empty value counts as unset, so CI can pass one conditionally
+fn build_revision() -> Option<&'static str> {
+    BUILD_REVISION.filter(|revision| !revision.is_empty())
+}
+
+// The package version, suffixed with the commit it was built from if known
+pub fn version() -> String {
+    build_revision().map_or_else(
+        || env!("CARGO_PKG_VERSION").to_owned(),
+        |revision| format!("{} ({revision})", env!("CARGO_PKG_VERSION")),
+    )
+}
+
 pub fn build_command() -> Command {
     // Note: clap 'wrap_help' is enabled to automatically wrap lines according to terminal width.
     // To keep things tidy though, short help descriptions should be no more than 54 characters,
@@ -22,7 +38,7 @@ pub fn build_command() -> Command {
     // Long help descriptions are soft wrapped here at 90 characters (column 91) but this does not
     // affect output, it simply matches what is rendered when help is output to a file.
     Command::new(env!("CARGO_PKG_NAME"))
-        .version(env!("CARGO_PKG_VERSION"))
+        .version(version())
         .author(env!("CARGO_PKG_AUTHORS"))
         .about(env!("CARGO_PKG_DESCRIPTION"))
         .styles(STYLES)

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ fn main() -> ExitCode {
     // Include version info in verbose output
     let is_verbose = matches.get_count("verbose") > 0;
     if is_verbose && !using_stdout {
-        println!("{} {}\n", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+        println!("{} {}\n", env!("CARGO_PKG_NAME"), cli::version());
     }
 
     let print_summary = !matches.get_flag("quiet") && !using_stdout;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -37,7 +37,10 @@ fn build_manpages() -> Result<(), Box<dyn Error>> {
     // `include!` evaluation
     let package_cmd = build_command()
         .name(package_meta.name.to_string())
-        .version(package_meta.version.to_string())
+        .version(build_revision().map_or_else(
+            || package_meta.version.to_string(),
+            |revision| format!("{} ({revision})", package_meta.version),
+        ))
         .author(package_meta.authors.first().unwrap_or(&String::new()))
         .about(package_meta.description.unwrap_or_default());
 


### PR DESCRIPTION
Fixes #727.

Disclaimer: I used AI for the Rust code.