### PR TITLE
Enhance manual.sh to copy oxipng manpage

### DIFF
--- a/scripts/manual.sh
+++ b/scripts/manual.sh
@@ -5,3 +5,5 @@ cargo xtask mangen
 ./target/debug/oxipng -V > MANUAL.txt
 #Redirect all streams to prevent detection of the terminal width and force an internal default of 100
 ./target/debug/oxipng --help >> MANUAL.txt 2>/dev/null </dev/null
+
+cp target/xtask/mangen/manpages/oxipng.1 oxipng.1


### PR DESCRIPTION
Include manpage copy in the manual generation process.

manpage is created with `cargo xtask mangen` in line 3 and no extra resourses are needed, just a plain copy to include it.

As a oxipng FreeBSD port maintainer, our port just need to pick manpage from source tarball and install it instead of compile xtask to generate it.

**Special note:**

This changes only the script.  The generated oxipng.1 is not included
here — running scripts/manual.sh once and committing the result is
needed for the file to reach the repository.

Note that clap_mangen stamps the generation date, so the file will show
a diff on every run of the script even with no CLI changes.  If you'd
prefer a deterministic date before committing it, that's worth settling
first.